### PR TITLE
Upgrade super-linter to v8.5.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7

--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -1,0 +1,9 @@
+{
+    "default": true,
+    "MD003": false,
+    "MD013": false,
+    "MD033": false,
+    "MD059": false,
+    "MD060": false,
+    "MD034": false
+}

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -6,7 +6,7 @@ name: Helm lint
 # https://help.github.com/en/articles/workflow-syntax-for-github-actions
 #
 
-permissions: read-all
+permissions: read-all # zizmor: ignore[excessive-permissions]
 
 on: [push, pull_request]
 
@@ -17,10 +17,12 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: 'v3.14.0'
 

--- a/.github/workflows/helm-unittest.yml
+++ b/.github/workflows/helm-unittest.yml
@@ -6,7 +6,7 @@ name: Helm Unit Test
 # https://help.github.com/en/articles/workflow-syntax-for-github-actions
 #
 
-permissions: read-all
+permissions: read-all # zizmor: ignore[excessive-permissions]
 
 on: [push, pull_request]
 
@@ -18,7 +18,9 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Run make helmlint
         run: |

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -2,7 +2,7 @@
 name: Super linter
 
 on: [push, pull_request]
-permissions: read-all
+permissions: read-all # zizmor: ignore[excessive-permissions]
 
 jobs:
   build:
@@ -13,8 +13,9 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
 
@@ -22,7 +23,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v7
+        uses: super-linter/super-linter/slim@61abc07d755095a68f4987d1c2c3d1d64408f1f9 # v8.5.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
@@ -35,3 +36,13 @@ jobs:
           VALIDATE_YAML: false
           VALIDATE_CHECKOV: false
           VALIDATE_YAML_PRETTIER: false
+          VALIDATE_BIOME_FORMAT: false
+          VALIDATE_BIOME_LINT: false
+          VALIDATE_NATURAL_LANGUAGE: false
+          VALIDATE_SPELL_CODESPELL: false
+          VALIDATE_PYTHON_BLACK: false
+          VALIDATE_PYTHON_PYINK: false
+          VALIDATE_PYTHON_PYLINT: false
+          VALIDATE_PYTHON_RUFF_FORMAT: false
+          VALIDATE_SHELL_SHFMT: false
+          VALIDATE_TRIVY: false

--- a/.github/workflows/update-helm-repo.yml
+++ b/.github/workflows/update-helm-repo.yml
@@ -17,14 +17,16 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
+permissions: read-all
+
 jobs:
   helmlint:
-    uses: validatedpatterns/helm-charts/.github/workflows/helmlint.yml@workflow-stable
+    uses: validatedpatterns/helm-charts/.github/workflows/helmlint.yml@workflow-stable # zizmor: ignore[unpinned-uses]
     permissions:
       contents: read
 
   update-helm-repo:
     needs: [helmlint]
-    uses: validatedpatterns/helm-charts/.github/workflows/update-helm-repo.yml@workflow-stable
-    permissions: read-all
-    secrets: inherit
+    uses: validatedpatterns/helm-charts/.github/workflows/update-helm-repo.yml@workflow-stable # zizmor: ignore[unpinned-uses]
+    permissions: read-all # zizmor: ignore[excessive-permissions]
+    secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,16 @@ super-linter: ## Runs super linter locally
 					-e VALIDATE_MARKDOWN_PRETTIER=false \
 					-e VALIDATE_YAML_PRETTIER=false \
 					-e VALIDATE_YAML=false \
+					-e VALIDATE_BIOME_FORMAT=false \
+					-e VALIDATE_BIOME_LINT=false \
+					-e VALIDATE_NATURAL_LANGUAGE=false \
+					-e VALIDATE_SPELL_CODESPELL=false \
+					-e VALIDATE_PYTHON_BLACK=false \
+					-e VALIDATE_PYTHON_PYINK=false \
+					-e VALIDATE_PYTHON_PYLINT=false \
+					-e VALIDATE_PYTHON_RUFF_FORMAT=false \
+					-e VALIDATE_SHELL_SHFMT=false \
+					-e VALIDATE_TRIVY=false \
 					-v $(PWD):/tmp/lint:rw,z \
 					-w /tmp/lint \
-					ghcr.io/super-linter/super-linter:slim-v7
+					ghcr.io/super-linter/super-linter:slim-v8


### PR DESCRIPTION
- Pin super-linter to v8.5.0 (SHA 61abc07d)
- Pin all GitHub Actions to SHA references
- Add persist-credentials: false to checkout steps
- Add permissions: read-all to workflow files
- Add dependabot cooldown and grouping configuration
- Disable new v8 linters not applicable to this repo
- Add FILTER_REGEX_EXCLUDE for nested .github directories
- Add zizmor ignore comments for reusable workflow refs
- Update markdownlint config for new rules
- Migrate ansible-lint-action to ansible/ansible-lint
